### PR TITLE
Fixed local IP reporting

### DIFF
--- a/Streaming/Listener/Listener.ino
+++ b/Streaming/Listener/Listener.ino
@@ -59,6 +59,11 @@ void initSparkVariables()
 void updateNetworkInfo()
 {
     IPAddress myIp = WiFi.localIP();
+    while(myIp[0] == 0) {
+      myIp = WiFi.localIP();
+      Particle.process();
+    }
+    
     sprintf(localIP, "%d.%d.%d.%d", myIp[0], myIp[1], myIp[2], myIp[3]);
     byte macAddr[6];
     WiFi.macAddress(macAddr);


### PR DESCRIPTION
This change fixes the reporting of the network information by calling `Particle.process()` as directed by @bkobkobko and @ScruffR.

Reference: https://community.particle.io/t/photon-ipaddress-0-0-0-0/18937/4
